### PR TITLE
Add HiWonder ADD_SERVO to add servo on runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 .vscode/
 !.vsode/launch.json
 !.vscode/settings.json
+.cache
 test/
 build2/
 build_rel/

--- a/include/module/Hiwonder_Servo.hpp
+++ b/include/module/Hiwonder_Servo.hpp
@@ -42,6 +42,8 @@ public:
     VOLTAGE_LIMIT_WRITE = 9,
     // motor mode write
     MOTOR_MODE_WRITE = 10,
+    // Add a servo
+    ADD_SERVO = 11,
   };
 
 private:

--- a/src/module/Hiwonder_Servo.cpp
+++ b/src/module/Hiwonder_Servo.cpp
@@ -182,7 +182,7 @@ void Hiwonder_Servo::writeModule(std::vector<uint8_t> &data) {
     this->servos[id]->motor_mode(speed);
   } else if (msg_type == ADD_SERVO) {
     // This is the actual servo ID
-    auto id = data[1]; 
+    auto id = data[1];
     auto servo = new HiwonderServo(this->bus, id);
     servo->initialize();
     // auto offset = servo->read_angle_offset();
@@ -191,8 +191,8 @@ void Hiwonder_Servo::writeModule(std::vector<uint8_t> &data) {
 
     servo->enable();
     std::vector<uint8_t> data = {
-        ADD_SERVO,   // add servo type
-        id,          // id
+        ADD_SERVO,                          // add servo type
+        id,                                 // id
         (uint8_t)(this->servos.size() - 1), // idx
     };
     this->publishData(data);

--- a/src/module/Hiwonder_Servo.cpp
+++ b/src/module/Hiwonder_Servo.cpp
@@ -180,6 +180,22 @@ void Hiwonder_Servo::writeModule(std::vector<uint8_t> &data) {
     uint16_t speed = decode_i16(data_span.subspan<2, sizeof(uint16_t)>());
     send_debug_info(10, speed);
     this->servos[id]->motor_mode(speed);
+  } else if (msg_type == ADD_SERVO) {
+    // This is the actual servo ID
+    auto id = data[1]; 
+    auto servo = new HiwonderServo(this->bus, id);
+    servo->initialize();
+    // auto offset = servo->read_angle_offset();
+    this->servos.push_back(servo);
+    this->enabled_servos++;
+
+    servo->enable();
+    std::vector<uint8_t> data = {
+        ADD_SERVO,   // add servo type
+        id,          // id
+        (uint8_t)(this->servos.size() - 1), // idx
+    };
+    this->publishData(data);
   }
 }
 


### PR DESCRIPTION
Enable functionality to add servos at runtime.
It should be backwards compatible with older versions of `tmx-cpp`.

Note: THIS CODE IS UNTESTED ON HARDWARE, DUE TO LACK OF HARDWARE.